### PR TITLE
[hcl] perf script to plot IPC

### DIFF
--- a/scripts/perf/ipc_load.sh
+++ b/scripts/perf/ipc_load.sh
@@ -1,0 +1,35 @@
+sudo ~/bin/perf stat -a -A -x ',' -e cycles,instructions --log-fd 1 -I 1000 | awk -F',' -W interactive '{ print $2" "$5" "$3}' | awk -W interactive '
+BEGIN {
+  printf "time";
+  c = "getconf _NPROCESSORS_ONLN";
+  c | getline cpus;
+  close(c);
+  for (i = 0; i < cpus; i++) {
+    printf(",cpu#" i ":ipc");
+  }
+  print "";
+  l = 0;
+}
+{
+  counter[$1, $2] = $3;
+  l += 1;
+
+
+  if (l == cpus * 2) {
+    c = "date +%H:%M:%S";
+    c | getline t;
+    printf t;
+    close(c);
+    for (i = 0; i < cpus; i++) {
+      inst = counter["CPU" i, "instructions"];
+      cycles = counter["CPU" i, "cycles"];
+      if (cycles == 0) {
+        cycles = 1;
+      }
+      printf("," counter["CPU" i, "instructions"] / counter["CPU" i, "cycles"]);
+    }
+    print "";
+    l = 0;
+  }
+}
+'


### PR DESCRIPTION
Measure and plot instructions/cycle.

Example usage:
scripts/perf/ipc_load.sh | hcl -x time -s 0.5..1..1.5
<img width="565" alt="Screen Shot 2020-01-29 at 23 00 31" src="https://user-images.githubusercontent.com/661042/73427240-2ee92300-42eb-11ea-97af-9dfc9e93590b.png">

Scale depends on system used and CPU bandwidth;