### PR TITLE
[hcl] refactor scales

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,6 +1,7 @@
 pub mod fetcher;
 pub mod metric_parse;
 pub mod scale;
+pub mod scale_config;
 pub mod series;
 pub mod series_collector;
 pub mod state;

--- a/src/data/scale.rs
+++ b/src/data/scale.rs
@@ -1,8 +1,131 @@
 use crate::data::metric_parse::metric_parse;
-use crate::data::series::Series;
-
-use std::collections::HashMap;
 use std::f64;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Scale {
+    a: f64,
+    b: f64,
+    c: f64,
+}
+
+impl Scale {
+    // linear transform from
+    // [a; b] -> [-1; 0] and
+    // [b; c] -> [0; 1]
+    fn new(a: f64, b: f64, c: f64) -> Result<Scale, ScaleError> {
+        if a == b || b == c {
+            return Err(ScaleError::EmptyDomain(a, b, c));
+        }
+        Ok(Scale { a, b, c })
+    }
+
+    // [a; b] -> [0; 1]
+    fn new_positive(a: f64, b: f64) -> Result<Scale, ScaleError> {
+        Scale::new(2.0 * a - b, a, b)
+    }
+
+    // [a; b] -> [-1; 0]
+    fn new_negative(a: f64, b: f64) -> Result<Scale, ScaleError> {
+        Scale::new(a, b, 2.0 * b - a)
+    }
+
+    // creates scale from min/max values.
+    pub fn from_min_max(mn: f64, mx: f64) -> Result<Scale, ScaleError> {
+        if mn > mx || !mn.is_finite() || !mx.is_finite() {
+            return Err(ScaleError::BadDomainConfig(format!(
+                "mn = {}, mx = {}",
+                mn, mx
+            )));
+        }
+        if mn * mx < 0.0 {
+            return Scale::new(mn, 0.0, mx);
+        }
+        // negative map:
+        if mn < 0.0 {
+            return Scale::new_negative(mn, 0.0);
+        }
+        if mx > 0.0 {
+            return Scale::new_positive(0.0, mx);
+        }
+        Scale::new(-1.0, 0.0, 1.0)
+    }
+
+    pub fn from_config(config: &str) -> Result<Scale, ScaleError> {
+        let v: Result<Vec<f64>, std::num::ParseFloatError> =
+            config.split("..").map(|v| metric_parse(v)).collect();
+        let v = v?;
+        match v.len() {
+            1 => Ok(Scale::new_positive(0.0, v[0])?),
+            2 => Ok(Scale::new_positive(v[0], v[1])?),
+            3 => Ok(Scale::new(v[0], v[1], v[2])?),
+            _ => Err(ScaleError::BadDomainConfig(config.to_string())),
+        }
+    }
+
+    // Find 'decent' scale for a given list of values.
+    // The logic is following:
+    //  - if there's no data at all, return identity map;
+    //  - if there's both negative and positive number, map [mn; 0; mx] -> [-1; 0; 1]
+    //  - if only negative or positive number present, map [mn; 0] -> [-1; 0] OR [0; mx] -> [0; 1]
+    pub fn auto(v: &[f64]) -> Scale {
+        match min_max(v) {
+            // Error here would indicate a bug in a program, so we unwrap
+            None => Scale::new(-1.0, 0.0, 1.0).unwrap(), // identity mapping
+            Some((mn, mx)) => Scale::from_min_max(mn, mx).unwrap(),
+        }
+    }
+
+    fn transform(from: (f64, f64), to: (f64, f64), v: f64) -> f64 {
+        to.0 + (to.1 - to.0) * (v - from.0) / (from.1 - from.0)
+    }
+
+    pub fn run(&self, v: f64) -> f64 {
+        if v < self.b {
+            Scale::transform((self.a, self.b), (-1.0, 0.0), v)
+        } else {
+            Scale::transform((self.b, self.c), (0.0, 1.0), v)
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn to_tuple(&self) -> (f64, f64, f64) {
+        (self.a, self.b, self.c)
+    }
+}
+
+impl Default for Scale {
+    fn default() -> Scale {
+        Scale::new(-1.0, 0.0, 1.0).unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub struct Scales {
+    scales: Vec<(String, Scale)>,
+}
+
+impl Scales {
+    // finds first one which matches the pattern
+    pub fn pick(&self, title: &str) -> Option<Scale> {
+        match self.scales.iter().find(|&(p, _)| title.contains(p)) {
+            Some((_, scale)) => Some(*scale),
+            None => None,
+        }
+    }
+
+    pub fn with_scales(scales: Vec<(String, Scale)>) -> Scales {
+        Scales { scales }
+    }
+}
+
+pub fn min_max(v: &[f64]) -> Option<(f64, f64)> {
+    v.iter()
+        .filter(|x| x.is_finite())
+        .fold(None, |acc, x| match acc {
+            None => Some((*x, *x)),
+            Some((mn, mx)) => Some((mn.min(*x), mx.max(*x))),
+        })
+}
 
 #[derive(Debug)]
 pub enum ScaleError {
@@ -33,218 +156,6 @@ impl std::fmt::Display for ScaleError {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct Scale {
-    a: f64,
-    b: f64,
-    c: f64,
-}
-
-impl Scale {
-    // linear transform from
-    // [a; b] -> [-1; 0] and
-    // [b; c] -> [0; 1]
-    pub fn new(a: f64, b: f64, c: f64) -> Result<Scale, ScaleError> {
-        if a == b || b == c {
-            return Err(ScaleError::EmptyDomain(a, b, c));
-        }
-        Ok(Scale { a, b, c })
-    }
-
-    // [a; b] -> [0; 1]
-    pub fn new_positive(a: f64, b: f64) -> Result<Scale, ScaleError> {
-        Scale::new(2.0 * a - b, a, b)
-    }
-
-    // [a; b] -> [-1; 0]
-    pub fn new_negative(a: f64, b: f64) -> Result<Scale, ScaleError> {
-        Scale::new(a, b, 2.0 * b - a)
-    }
-
-    // creates scale from min/max values. 
-    pub fn from_min_max(mn: f64, mx: f64) -> Result<Scale, ScaleError> {
-        if mn > mx || !mn.is_finite() || !mx.is_finite() {
-            return Err(ScaleError::BadDomainConfig(format!(
-                "mn = {}, mx = {}",
-                mn, mx
-            )));
-        }
-        if mn * mx < 0.0 {
-            return Scale::new(mn, 0.0, mx);
-        }
-        // negative map:
-        if mn < 0.0 {
-            return Scale::new_negative(mn, 0.0);
-        }
-        if mx > 0.0 {
-            return Scale::new_positive(0.0, mx);
-        }
-        Scale::new(-1.0, 0.0, 1.0)
-    }
-
-    // Find 'decent' scale for a given list of values.
-    // The logic is following:
-    //  - if there's no data at all, return identity map;
-    //  - if there's both negative and positive number, map [mn; 0; mx] -> [-1; 0; 1]
-    //  - if only negative or positive number present, map [mn; 0] -> [-1; 0] OR [0; mx] -> [0; 1]
-    pub fn auto(v: &[f64]) -> Scale {
-        match min_max(v) {
-            // Error here would indicate a bug in a program, so we unwrap
-            None => Scale::new(-1.0, 0.0, 1.0).unwrap(), // identity mapping
-            Some((mn, mx)) => Scale::from_min_max(mn, mx).unwrap(),
-        }
-    }
-
-    fn transform(from: (f64, f64), to: (f64, f64), v: f64) -> f64 {
-        to.0 + (to.1 - to.0) * (v - from.0) / (from.1 - from.0)
-    }
-
-    pub fn run(&self, v: f64) -> f64 {
-        if v < self.b {
-            Scale::transform((self.a, self.b), (-1.0, 0.0), v)
-        } else {
-            Scale::transform((self.b, self.c), (0.0, 1.0), v)
-        }
-    }
-
-    pub fn from_config(config: &str) -> Result<Scale, ScaleError> {
-        let v: Result<Vec<f64>, std::num::ParseFloatError> =
-            config.split("..").map(|v| metric_parse(v)).collect();
-        let v = v?;
-        match v.len() {
-            1 => Ok(Scale::new_positive(0.0, v[0])?),
-            2 => Ok(Scale::new_positive(v[0], v[1])?),
-            3 => Ok(Scale::new(v[0], v[1], v[2])?),
-            _ => Err(ScaleError::BadDomainConfig(config.to_string())),
-        }
-    }
-}
-
-impl Default for Scale {
-    fn default() -> Scale {
-        Scale::new(-1.0, 0.0, 1.0).unwrap()
-    }
-}
-
-#[derive(Debug)]
-pub enum ScaleHolder {
-    Regular(Scale),
-    Auto,
-}
-
-impl ScaleHolder {
-    pub fn from_config(conf: &str) -> Result<Self, ScaleError> {
-        if conf == "auto" {
-            Ok(ScaleHolder::Auto)
-        } else {
-            Ok(ScaleHolder::Regular(Scale::from_config(conf)?))
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct Scales {
-    scales: Vec<(String, ScaleHolder)>, // we need to configure 'regular scale' vs 'auto scale'
-}
-
-impl Scales {
-    // example config format:  250.0..1000..2000,qps:100000,cpu:0..100
-    pub fn from_config(conf: &str) -> Result<Scales, ScaleError> {
-        let mut catch_all: Option<(String, ScaleHolder)> = None;
-        let scales: Result<Vec<Option<(String, ScaleHolder)>>, ScaleError> = conf
-            .split(',')
-            .map(|s| {
-                let parts = s.split(':').collect::<Vec<&str>>();
-
-                match parts.len() {
-                    1 => {
-                        catch_all = Some(("".to_owned(), ScaleHolder::from_config(&parts[0])?));
-                        Ok(None)
-                    }
-                    2 => Ok(Some((
-                        parts[0].to_owned(),
-                        ScaleHolder::from_config(&parts[1])?,
-                    ))),
-                    _ => Err(ScaleError::BadFormat(conf.to_owned())),
-                }
-            })
-            .collect();
-
-        let mut res: Vec<(String, ScaleHolder)> = scales?.into_iter().filter_map(|v| v).collect();
-
-        // catch all is last
-        if let Some(v) = catch_all {
-            res.push(v);
-        }
-
-        Ok(Scales { scales: res })
-    }
-
-    // returns 'finalized' version where no 'auto' will exist
-    pub fn with_data(&self, series: &[Series]) -> Scales {
-        Scales {
-            scales: {
-                let mut bounds = HashMap::new();
-                series.iter().for_each(|s| {
-                    // if it's autoscale matching the series
-                    if let Some((pattern, ScaleHolder::Auto)) =
-                        self.scales.iter().find(|&(p, _)| s.title.contains(p))
-                    {
-                        // and if there's valid min and max values for the series
-                        if let Some((mn, mx)) = min_max(&s.values) {
-                            bounds
-                                .entry(pattern)
-                                .and_modify(|v: &mut (f64, f64)| {
-                                    v.0 = v.0.min(mn);
-                                    v.1 = v.1.max(mx);
-                                })
-                                .or_insert((mn, mx));
-                        }
-                    }
-                });
-                // TODO: shall auto catch-on group by?
-                // looks like it all good. If there's no scale matching series at all, it still won't match;
-                self.scales
-                    .iter()
-                    .map(|s| match s {
-                        (title, ScaleHolder::Auto) => {
-                            if let Some((mn, mx)) = bounds.get(title) {
-                                (
-                                    title.to_owned(),
-                                    ScaleHolder::Regular(Scale::from_min_max(*mn, *mx).unwrap()),
-                                )
-                            } else {
-                                (title.to_owned(), ScaleHolder::Regular(Scale::default()))
-                            }
-                        }
-                        (title, ScaleHolder::Regular(scale)) => {
-                            (title.to_owned(), ScaleHolder::Regular(*scale))
-                        }
-                    })
-                    .collect()
-            },
-        }
-    }
-
-    // finds first one which matches the pattern
-    pub fn pick(&self, title: &str) -> Option<Scale> {
-        match self.scales.iter().find(|&(p, _)| title.contains(p)) {
-            Some((_, ScaleHolder::Regular(scale))) => Some(*scale),
-            Some((_, ScaleHolder::Auto)) => None,
-            None => None,
-        }
-    }
-}
-
-fn min_max(v: &[f64]) -> Option<(f64, f64)> {
-    v.iter()
-        .filter(|x| x.is_finite())
-        .fold(None, |acc, x| match acc {
-            None => Some((*x, *x)),
-            Some((mn, mx)) => Some((mn.min(*x), mx.max(*x))),
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,42 +167,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_default() {
-        assert_eq!(
-            Scales::from_config("1..2..3,x:2..3..4")
-                .unwrap()
-                .scales
-                .len(),
-            2
-        );
-    }
-
-    #[test]
     fn scale_failures() {
         assert!(Scale::new(0.0, 0.0, 1.0).is_err());
         assert!(Scale::new_positive(1.0, 1.0).is_err());
         assert!(Scale::new_negative(10.0, 10.0).is_err());
-    }
-
-    macro_rules! assert_match {
-        ($what:expr, $($pattern:tt)+) => {
-            if let $($pattern)+ = $what {} else {
-                panic!("assertion failed: `{}` does not match `{}`", stringify!($what), stringify!($($pattern)+));
-            }
-        }
-    }
-
-    #[test]
-    fn parse_failures() {
-        assert_match!(
-            Scales::from_config("1..2..qq"),
-            Err(ScaleError::NumberParse(_))
-        );
-        assert_match!(
-            Scales::from_config("1..2..3..4"),
-            Err(ScaleError::BadDomainConfig(_))
-        );
-        assert_match!(Scales::from_config("xyz"), Err(ScaleError::NumberParse(_)));
     }
 
     #[test]
@@ -363,18 +242,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_scales_and_run() {
-        let scales = Scales::from_config("-100..0..100,x:-100..0..1000,z:500,w:-200..200").unwrap();
-        assert_approx_eq!(scales.pick("x").unwrap().run(10.0), 0.01);
-        assert_approx_eq!(scales.pick("y").unwrap().run(10.0), 0.1);
-        assert_approx_eq!(scales.pick("y").unwrap().run(-10.0), -0.1);
-        assert_approx_eq!(scales.pick("z").unwrap().run(250.0), 0.5);
-        assert_approx_eq!(scales.pick("z").unwrap().run(-250.0), -0.5);
-        assert_approx_eq!(scales.pick("w").unwrap().run(-100.0), 0.25);
-        assert_approx_eq!(scales.pick("w").unwrap().run(-300.0), -0.25);
-    }
-
-    #[test]
     fn min_max_test() {
         let t = min_max(&vec![0.0, 1.0, 2.0]);
         assert_approx_eq!(t.unwrap().0, 0.0);
@@ -392,35 +259,5 @@ mod tests {
         let t = min_max(&vec![0.0, f64::NAN]);
         assert_approx_eq!(t.unwrap().0, 0.0);
         assert_approx_eq!(t.unwrap().1, 0.0);
-    }
-
-    #[test]
-    fn with_data() {
-        let s = vec![
-            Series {
-                title: "cpu1".to_owned(),
-                values: vec![0.0, 10.0, 11.0, 9.0],
-            },
-            Series {
-                title: "cpu2".to_owned(),
-                values: vec![0.0, 100.0, 11.0, 99.0],
-            },
-            Series {
-                title: "ram_free_mb".to_owned(),
-                values: vec![1111.0, 999.0, 888.0, 99.0],
-            },
-        ];
-        let scales = Scales::from_config("cpu:auto").unwrap();
-        let scales = scales.with_data(&s);
-        // in this case, cpu will be auto, ram will be also 'auto' but separate
-
-        let cpu_scale = scales.pick("cpu1").unwrap();
-        assert_approx_eq!(cpu_scale.a, -100.0);
-        assert_approx_eq!(cpu_scale.b, 0.0);
-        assert_approx_eq!(cpu_scale.c, 100.0);
-        let cpu_scale = scales.pick("cpu2").unwrap();
-        assert_approx_eq!(cpu_scale.a, -100.0);
-        assert_approx_eq!(cpu_scale.b, 0.0);
-        assert_approx_eq!(cpu_scale.c, 100.0);
     }
 }

--- a/src/data/scale_config.rs
+++ b/src/data/scale_config.rs
@@ -1,0 +1,208 @@
+use crate::data::scale::{min_max, Scale, ScaleError, Scales};
+use crate::data::series::Series;
+
+use std::collections::HashMap;
+use std::f64;
+
+#[derive(Debug)]
+pub enum ScaleConfigType {
+    Regular(Scale),
+    Auto,
+}
+
+impl ScaleConfigType {
+    pub fn new(conf: &str) -> Result<ScaleConfigType, ScaleError> {
+        if conf == "auto" {
+            Ok(ScaleConfigType::Auto)
+        } else {
+            Ok(ScaleConfigType::Regular(Scale::from_config(conf)?))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ScaleConfig {
+    pattern: String,
+    config: ScaleConfigType,
+}
+
+impl ScaleConfig {
+    pub fn new(pattern: &str, conf: &str) -> Result<ScaleConfig, ScaleError> {
+        Ok(ScaleConfig {
+            pattern: pattern.to_owned(),
+            config: ScaleConfigType::new(conf)?,
+        })
+    }
+
+    fn make_scale(&self, bounds: &HashMap<String, (f64, f64)>) -> (String, Scale) {
+        match self.config {
+            ScaleConfigType::Auto => {
+                if let Some((mn, mx)) = bounds.get(&self.pattern) {
+                    (self.pattern.clone(), Scale::from_min_max(*mn, *mx).unwrap())
+                } else {
+                    (self.pattern.clone(), Scale::default())
+                }
+            }
+            ScaleConfigType::Regular(scale) => (self.pattern.to_owned(), scale),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ScalesConfig {
+    entries: Vec<ScaleConfig>,
+}
+
+impl ScalesConfig {
+    pub fn new(conf: &str) -> Result<ScalesConfig, ScaleError> {
+        let mut wildcard: Option<ScaleConfig> = None;
+        let scales: Result<Vec<Option<ScaleConfig>>, ScaleError> = conf
+            .split(',')
+            .map(|s| {
+                let parts = s.split(':').collect::<Vec<&str>>();
+
+                match parts.len() {
+                    1 => {
+                        wildcard = Some(ScaleConfig::new("", &parts[0])?);
+                        Ok(None)
+                    }
+                    2 => Ok(Some(ScaleConfig::new(&parts[0], &parts[1])?)),
+                    _ => Err(ScaleError::BadFormat(conf.to_owned())),
+                }
+            })
+            .collect();
+
+        let mut res: Vec<ScaleConfig> = scales?.into_iter().filter_map(|v| v).collect();
+
+        // wildcard is last
+        if let Some(v) = wildcard {
+            res.push(v);
+        }
+
+        Ok(ScalesConfig { entries: res })
+    }
+
+    // finds first matching scale config for a series title,
+    // and, if it's 'autoscale' returns it. If the match is
+    // not autoscale, or no result was found, None is returned.
+    fn find_auto(&self, title: &str) -> Option<&ScaleConfig> {
+        self.entries
+            .iter()
+            .find(|c| title.contains(&c.pattern))
+            .filter(|c| match c.config {
+                ScaleConfigType::Auto => true,
+                _ => false,
+            })
+    }
+
+    // for each autoscale config, computes min/max values in the data.
+    fn bounds(&self, series: &[Series]) -> HashMap<String, (f64, f64)> {
+        let mut bounds = HashMap::new();
+        series.iter().for_each(|s| {
+            // if it's autoscale matching the series
+            if let Some(scale_config) = self.find_auto(&s.title) {
+                // and if there's valid min and max values for the series
+                if let Some((mn, mx)) = min_max(&s.values) {
+                    bounds
+                        .entry(scale_config.pattern.clone())
+                        .and_modify(|v: &mut (f64, f64)| {
+                            v.0 = v.0.min(mn);
+                            v.1 = v.1.max(mx);
+                        })
+                        .or_insert((mn, mx));
+                }
+            }
+        });
+        bounds
+    }
+
+    pub fn materialize(&self, series: &[Series]) -> Scales {
+        Scales::with_scales({
+            let bounds = self.bounds(series);
+            self.entries.iter().map(|s| s.make_scale(&bounds)).collect()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+
+    #[test]
+    fn parse_default() {
+        assert_eq!(
+            ScalesConfig::new("1..2..3,x:2..3..4")
+                .unwrap()
+                .entries
+                .len(),
+            2
+        );
+    }
+
+    macro_rules! assert_match {
+        ($what:expr, $($pattern:tt)+) => {
+            if let $($pattern)+ = $what {} else {
+                panic!("assertion failed: `{}` does not match `{}`", stringify!($what), stringify!($($pattern)+));
+            }
+        }
+    }
+
+    #[test]
+    fn parse_failures() {
+        assert_match!(
+            ScalesConfig::new("1..2..qq"),
+            Err(ScaleError::NumberParse(_))
+        );
+        assert_match!(
+            ScalesConfig::new("1..2..3..4"),
+            Err(ScaleError::BadDomainConfig(_))
+        );
+        assert_match!(ScalesConfig::new("xyz"), Err(ScaleError::NumberParse(_)));
+    }
+
+    #[test]
+    fn parse_scales_and_run() {
+        let scales = ScalesConfig::new("-100..0..100,x:-100..0..1000,z:500,w:-200..200").unwrap();
+        let scales = scales.materialize(&vec![]);
+        assert_approx_eq!(scales.pick("x").unwrap().run(10.0), 0.01);
+        assert_approx_eq!(scales.pick("y").unwrap().run(10.0), 0.1);
+        assert_approx_eq!(scales.pick("y").unwrap().run(-10.0), -0.1);
+        assert_approx_eq!(scales.pick("z").unwrap().run(250.0), 0.5);
+        assert_approx_eq!(scales.pick("z").unwrap().run(-250.0), -0.5);
+        assert_approx_eq!(scales.pick("w").unwrap().run(-100.0), 0.25);
+        assert_approx_eq!(scales.pick("w").unwrap().run(-300.0), -0.25);
+    }
+
+    #[test]
+    fn materialized() {
+        let s = vec![
+            Series {
+                title: "cpu1".to_owned(),
+                values: vec![0.0, 10.0, 11.0, 9.0],
+            },
+            Series {
+                title: "cpu2".to_owned(),
+                values: vec![0.0, 100.0, 11.0, 99.0],
+            },
+            Series {
+                title: "ram_free_mb".to_owned(),
+                values: vec![1111.0, 999.0, 888.0, 99.0],
+            },
+        ];
+        let scales = ScalesConfig::new("cpu:auto").unwrap();
+        let scales = scales.materialize(&s);
+        // in this case, cpu will be auto, ram will be also 'auto' but separate
+
+        let cpu_scale = scales.pick("cpu1").unwrap();
+        let (a, b, c) = cpu_scale.to_tuple();
+        assert_approx_eq!(a, -100.0);
+        assert_approx_eq!(b, 0.0);
+        assert_approx_eq!(c, 100.0);
+        let cpu_scale = scales.pick("cpu2").unwrap();
+        let (a, b, c) = cpu_scale.to_tuple();
+        assert_approx_eq!(a, -100.0);
+        assert_approx_eq!(b, 0.0);
+        assert_approx_eq!(c, 100.0);
+    }
+}

--- a/src/data/state.rs
+++ b/src/data/state.rs
@@ -1,6 +1,6 @@
 use crate::app::settings::Settings;
 use crate::app::window::{Window, WindowAdjust};
-use crate::data::scale::Scales;
+use crate::data::scale_config::ScalesConfig;
 use crate::data::series::SeriesSet;
 
 use termion::event::{Key, MouseButton};
@@ -11,7 +11,7 @@ pub struct State {
     pub error_message: Option<String>,
     pub x: Window,
     pub y: Window,
-    pub scales: Option<Scales>,
+    pub scales: Option<ScalesConfig>,
     auto: bool,
 }
 
@@ -26,7 +26,7 @@ impl State {
                 .scales
                 .as_ref()
                 .map(String::as_str)
-                .map(|s| Scales::from_config(s).unwrap()),
+                .map(|s| ScalesConfig::new(s).unwrap()),
             auto: true,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod data;
 mod platform;
 mod ui;
 
-use crate::data::scale::Scales;
+use crate::data::scale_config::ScalesConfig;
 use app::settings::{Settings, XColumn};
 use clap::{App, AppSettings, Arg, ArgGroup};
 
@@ -68,10 +68,16 @@ cpu:100,ram:16G,wow_change:95..100..105 will break down into 3 scales.
 Series with titles like 'cpu#1' will match first scale, thus, using [0;100] -> [0;1];
 Series like 'ram_total', 'ram_free', 'ram_cache' will match second.
 Series 'revenue_wow_change' will use [95;100;105] -> [-1;0;1] scale.
+
+It's possible to have autoscale groups configured. This could be very useful when several
+series have same semantics and should share the scale. For example, in
+'cycles:auto,instructions:auto,ram:32G', all series with titles matching 'cycles' 
+will compute one shared scale. Another group of series matching 'instructions' will have 
+another single shared autoscale.
     ",
                 )
                 .validator(|s| {
-                    Scales::from_config(&s)
+                    ScalesConfig::new(&s)
                         .map(|_| ())
                         .map_err(|e| format!("{}", e))
                 })

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -38,7 +38,7 @@ impl<'a> Widget for Charts<'a> {
             .state
             .scales
             .as_ref()
-            .map(|s| s.with_data(&self.state.data.y));
+            .map(|s| s.materialize(&self.state.data.y));
 
         // charts
         self.state


### PR DESCRIPTION
split scales to 'scale-config' (pre-autogeneration) and materialized
scales, built with the data available.